### PR TITLE
Consolidate generic source types into single GENERIC SourceType

### DIFF
--- a/src/potluck/models/base.py
+++ b/src/potluck/models/base.py
@@ -34,10 +34,7 @@ class SourceType(str, Enum):
     REDDIT = "reddit"
     WHATSAPP = "whatsapp"
     YNAB = "ynab"
-    IMAGE_FOLDER = "image_folder"  # Generic image/media folder import
-    TEXT_FILES = "text_files"  # Plain text / Markdown / Obsidian vault import
-    MBOX = "mbox"  # MBOX email files (Thunderbird, Apple Mail, etc.)
-    GENERIC = "generic"  # Bulk import of generic files
+    GENERIC = "generic"  # Generic file-based imports (images, text, MBOX, etc.)
     MANUAL = "manual"  # User-created content within Potluck (notes, annotations)
 
 

--- a/src/potluck/models/notes.py
+++ b/src/potluck/models/notes.py
@@ -2,7 +2,7 @@
 
 KnowledgeNotes store useful information as searchable text. They can be:
 - Created manually by users or LLMs within Potluck (source_type=MANUAL)
-- Imported from external sources like Obsidian vaults or text files (source_type=TEXT_FILES)
+- Imported from external sources like Obsidian vaults or text files (source_type=GENERIC)
 
 Think of it as an LLM memory function - capturing insights, facts, and
 relationships that don't have a hard tie to a source but can benefit

--- a/src/potluck/pipeline/ingestion/image_folder/__init__.py
+++ b/src/potluck/pipeline/ingestion/image_folder/__init__.py
@@ -24,7 +24,7 @@ class ImageFolderStage(BaseIngestionStage):
     Scans any directory recursively for images, videos, and audio files.
     """
 
-    SOURCE_TYPE: ClassVar[SourceType] = SourceType.IMAGE_FOLDER
+    SOURCE_TYPE: ClassVar[SourceType] = SourceType.GENERIC
 
     FILENAME_PATTERNS: ClassVar[list[str]] = [
         r"photos",

--- a/src/potluck/pipeline/ingestion/image_folder/images.py
+++ b/src/potluck/pipeline/ingestion/image_folder/images.py
@@ -123,7 +123,7 @@ def _process_file(
         pass
 
     return Media(
-        source_type=SourceType.IMAGE_FOLDER,
+        source_type=SourceType.GENERIC,
         source_id=str(file_path),
         content_hash=file_hash,
         occurred_at=occurred_at,

--- a/src/potluck/pipeline/ingestion/mbox/__init__.py
+++ b/src/potluck/pipeline/ingestion/mbox/__init__.py
@@ -30,7 +30,7 @@ class MboxStage(BaseIngestionStage):
     MBOX files (e.g., Thunderbird profile directories).
     """
 
-    SOURCE_TYPE: ClassVar[SourceType] = SourceType.MBOX
+    SOURCE_TYPE: ClassVar[SourceType] = SourceType.GENERIC
 
     FILENAME_PATTERNS: ClassVar[list[str]] = [
         r".*\.mbox",  # Standard .mbox files

--- a/src/potluck/pipeline/ingestion/mbox/emails.py
+++ b/src/potluck/pipeline/ingestion/mbox/emails.py
@@ -112,7 +112,7 @@ def ingest_emails(
     for root_id, stats in thread_stats.items():
         thread = EmailThread(
             id=uuid4(),
-            source_type=SourceType.MBOX,
+            source_type=SourceType.GENERIC,
             source_id=f"mbox_thread_{root_id}",
             content_hash=hashlib.sha256(root_id.encode()).hexdigest(),
             subject=stats.subject,
@@ -309,7 +309,7 @@ def _create_email(
 
     return Email(
         id=uuid4(),
-        source_type=SourceType.MBOX,
+        source_type=SourceType.GENERIC,
         source_id=mbox_msg.message_id or f"mbox_{uuid4().hex[:12]}",
         content_hash=content_hash,
         occurred_at=mbox_msg.date,

--- a/src/potluck/pipeline/ingestion/text_files/__init__.py
+++ b/src/potluck/pipeline/ingestion/text_files/__init__.py
@@ -32,7 +32,7 @@ class TextFilesStage(BaseIngestionStage):
     Detects Obsidian vaults by the presence of a .obsidian/ directory.
     """
 
-    SOURCE_TYPE: ClassVar[SourceType] = SourceType.TEXT_FILES
+    SOURCE_TYPE: ClassVar[SourceType] = SourceType.GENERIC
 
     FILENAME_PATTERNS: ClassVar[list[str]] = [
         r"notes",

--- a/src/potluck/pipeline/ingestion/text_files/notes.py
+++ b/src/potluck/pipeline/ingestion/text_files/notes.py
@@ -129,7 +129,7 @@ def _process_file(file_path: Path, base_path: Path) -> KnowledgeNote | None:
         relative_path = file_path.name
 
     return KnowledgeNote(
-        source_type=SourceType.TEXT_FILES,
+        source_type=SourceType.GENERIC,
         source_id=relative_path,
         content_hash=compute_content_hash(content_body),
         content=content_body,

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -47,10 +47,7 @@ class TestSourceType:
         expected = {
             "android_timeline",
             "google_takeout",
-            "image_folder",
-            "mbox",
             "reddit",
-            "text_files",
             "whatsapp",
             "ynab",
             "generic",

--- a/tests/unit/pipeline/ingestion/image_folder/test_images.py
+++ b/tests/unit/pipeline/ingestion/image_folder/test_images.py
@@ -85,7 +85,7 @@ class TestImageIngestion:
 
         media_entities = [e for e in entities if isinstance(e, Media)]
         assert len(media_entities) == 2
-        assert all(m.source_type == SourceType.IMAGE_FOLDER for m in media_entities)
+        assert all(m.source_type == SourceType.GENERIC for m in media_entities)
 
     def test_media_fields(self, tmp_path: Path) -> None:
         """Media entity fields are populated correctly."""

--- a/tests/unit/pipeline/ingestion/mbox/test_emails.py
+++ b/tests/unit/pipeline/ingestion/mbox/test_emails.py
@@ -101,7 +101,7 @@ class TestMboxEmailIngestion:
         assert alice_email.from_address == "alice@example.com"
         assert alice_email.from_name == "Alice Smith"
         assert alice_email.subject == "Project Update"
-        assert alice_email.source_type == SourceType.MBOX
+        assert alice_email.source_type == SourceType.GENERIC
         assert alice_email.body_text is not None
         assert "project update" in alice_email.body_text.lower()
 

--- a/tests/unit/pipeline/ingestion/text_files/test_notes.py
+++ b/tests/unit/pipeline/ingestion/text_files/test_notes.py
@@ -67,7 +67,7 @@ class TestTextFileIngestion:
 
         notes = [e for e in entities if isinstance(e, KnowledgeNote)]
         assert len(notes) == 2
-        assert all(n.source_type == SourceType.TEXT_FILES for n in notes)
+        assert all(n.source_type == SourceType.GENERIC for n in notes)
         assert all(n.created_by == "import" for n in notes)
 
     def test_relative_source_id(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Remove `IMAGE_FOLDER`, `TEXT_FILES`, and `MBOX` from `SourceType` enum
- All three generic file-based ingesters (image folder, text files, MBOX) now use `SourceType.GENERIC`
- Simplifies the enum by distinguishing platform-specific sources (Reddit, WhatsApp, YNAB) from generic file imports

## Test plan
- [x] All 689 unit tests pass
- [x] ruff check/format clean
- [x] mypy clean (187 source files)
- [x] Pre-push Docker test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)