### PR TITLE
fix(bench): nightly full tier green — subprocess env scrub + VmHWM measurement

### DIFF
--- a/tests/unit/bench/test_p2_budgets.py
+++ b/tests/unit/bench/test_p2_budgets.py
@@ -47,7 +47,13 @@ print(f"{run.id} {run.items_new} {run.items_duplicate} {elapsed:.2f} {rss_kb}")
 def _import_subprocess(
     archive: Path, data_home: Path, extra_env: dict[str, str] | None = None
 ) -> tuple[int, int, int, float, int]:
-    env = dict(os.environ, XDG_DATA_HOME=str(data_home), XDG_CONFIG_HOME=str(data_home / "cfg"))
+    # Scrub inherited POTLUCK_* (matching tests/e2e/conftest.py): the autouse
+    # isolated_dirs fixture pins POTLUCK_DB_PATH in the pytest process, and env
+    # beats the XDG-derived default — without this, every subprocess of one
+    # test would share a single database regardless of its data_home, and
+    # cross-import content dedup would corrupt the counts being asserted.
+    env = {k: v for k, v in os.environ.items() if not k.startswith("POTLUCK_")}
+    env.update(XDG_DATA_HOME=str(data_home), XDG_CONFIG_HOME=str(data_home / "cfg"))
     env.update(extra_env or {})
     proc = subprocess.run(
         [sys.executable, "-c", _DRIVER, str(archive)],

--- a/tests/unit/bench/test_p2_budgets.py
+++ b/tests/unit/bench/test_p2_budgets.py
@@ -5,9 +5,11 @@ Budgets (4-core CPU CI-class):
 - no-op re-run of the same archive < 60 s (ledger short-circuit)
 - superset re-import ingests only the delta at 10k -> 12k
 
-The import runs in a SUBPROCESS so ru_maxrss reflects the import alone, and
-the no-op re-run pays the honest cost (interpreter start, file hash of the
-full archive) in a fresh process.
+The import runs in a SUBPROCESS so its peak RSS is measured alone — via
+VmHWM, not ru_maxrss, because a child's ru_maxrss is polluted by the
+spawning pytest process's resident set (mechanism documented in
+test_p2_mbox_rss.py) — and the no-op re-run pays the honest cost
+(interpreter start, file hash of the full archive) in a fresh process.
 """
 
 import os
@@ -28,7 +30,7 @@ _RSS_BUDGET_KB = 1_572_864  # 1.5 GB
 _NOOP_BUDGET_S = 60
 
 _DRIVER = """
-import resource, sys, time
+import sys, time
 from pathlib import Path
 from potluck.services.context import create_context
 from potluck.services.imports import import_path
@@ -38,7 +40,10 @@ started = time.perf_counter()
 runs = import_path(ctx, Path(sys.argv[1]))
 elapsed = time.perf_counter() - started
 ctx.db.close()
-rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss  # KB on Linux
+# VmHWM (KB), not ru_maxrss — a child's ru_maxrss is polluted by the spawning
+# pytest process's resident set (mechanism in test_p2_mbox_rss.py).
+with open("/proc/self/status") as f:
+    rss_kb = next(int(line.split()[1]) for line in f if line.startswith("VmHWM:"))
 [run] = runs
 print(f"{run.id} {run.items_new} {run.items_duplicate} {elapsed:.2f} {rss_kb}")
 """

--- a/tests/unit/bench/test_p2_mbox_rss.py
+++ b/tests/unit/bench/test_p2_mbox_rss.py
@@ -4,6 +4,18 @@ Nightly tier (@pytest.mark.bench): generates ~1 GB in tmp, parses it in a
 SUBPROCESS (ru_maxrss is a process-lifetime high-water mark — sibling tests
 would pollute an in-process measurement), and asserts peak RSS stays far below
 the corpus size. Nothing large is ever committed.
+
+A subprocess alone is NOT enough, and ru_maxrss must not be the metric: the
+fork/vfork child starts with the parent's mm (shared or copied), and execve
+folds that pre-exec mm's high-water mark into the child's signal->maxrss —
+which getrusage reports and nothing (not even /proc/self/clear_refs) can
+reset. A fresh child's ru_maxrss is therefore max(parent RSS at spawn, own
+true peak); in the full bench tier that parent is the pytest runner sitting
+at ~455 MB after the in-process 250k-FTS-corpus test, which is exactly what
+the nightly measured (452-455 MB, deterministic, four nights) while the
+parse itself peaks at ~90 MB. The driver reads VmHWM from /proc/self/status
+instead: that reads only the CURRENT mm's watermark, which execve starts
+fresh (verified: 500 MB parent -> child VmHWM 16 MB, child ru_maxrss 518 MB).
 """
 
 import subprocess
@@ -20,7 +32,7 @@ _BODY_KB = 500
 _MAX_RSS_MB = 300
 
 _DRIVER = """
-import resource, sys
+import sys
 from potluck.ingest.mbox import iter_mbox_messages, parse_email
 
 count = 0
@@ -29,7 +41,10 @@ with open(sys.argv[1], "rb") as f:
         parsed = parse_email(raw)
         count += 1
 
-rss_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss  # KB on Linux
+# VmHWM (KB), not ru_maxrss — see module docstring: a child's ru_maxrss is
+# floored at the spawning process's resident set as of fork/vfork.
+with open("/proc/self/status") as f:
+    rss_kb = next(int(line.split()[1]) for line in f if line.startswith("VmHWM:"))
 print(f"{count} {rss_kb}")
 """
 


### PR DESCRIPTION
Unblocks the v1.0.0-beta.1 tag (#141 requires full bench green). The two nightly failures on main were **measurement-harness defects, not product regressions**:

1. **Scaling test (6000≠8000)**: the unit-tier conftest's autouse `POTLUCK_DB_PATH` leaked into the bench import subprocesses (env beats the XDG dirs the driver pins), so the 2k and 8k scales imported into ONE shared DB — and since the synthetic generator makes the first N messages of a larger corpus byte-identical, content-hash dedup ate exactly 2000 items. Fix: scrub inherited `POTLUCK_*` from the child env (same pattern as tests/e2e and testing/server). Collateral repair: the pooled-vs-sequential A/B gate had been silently timing a ledger no-op in that shared DB — it now measures real work (CI ratio 0.56 vs the 0.8 gate).
2. **RSS test (454MB > 300MB)**: `ru_maxrss` in the measurement child is floored at the *spawning* pytest process's high-water mark (execve folds the inherited mm watermark into `signal->maxrss`), so the reading tracked whatever heavy test ran before it in-process — matching all four red nights. The drivers now read `VmHWM` from /proc (execve-fresh, loud on surprise); the true parse peak is 83–90 MB against the unchanged 300 MB budget. The 50k test's 1.5 GB assertion had the same latent defect and is fixed too.

No budgets weakened, no baselines touched, diff surface = the two test files. Verified: worst-case-order repro red→green; unit tier 693; static gates; **nightly full tier green on CI for this branch (run 28905862118: 14 bench tests + compare ±30%)**. Review: approved, with the kernel mechanism independently reproduced by the reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tkik7zNrqgKoUvZyFCmAKc