### PR TITLE
fix: deterministic gdrive prune integration test

### DIFF
--- a/tests/unit/services/test_gdrive_integration.py
+++ b/tests/unit/services/test_gdrive_integration.py
@@ -148,9 +148,25 @@ def test_prune_after_verified_import_end_to_end(ctx: AppContext, tmp_path: Path)
     assert gdrive_service.start_puller(gctx, transport=mock.transport()) is True
     assert watch_service.start_watcher(gctx) is True
     try:
-        _wait_for(lambda: sorted(mock.deleted) == sorted(ids), "prune of the imported set")
+        # Wait on the DURABLE terminal state — pruned_at stamped on every
+        # row — never on the mock's deleted list: _prune issues files.delete
+        # (which updates mock.deleted) BEFORE ops.mark_pruned queues its
+        # write to the single writer thread, so a wait keyed on the mock can
+        # win the race against the stamp and observe pruned_at=None rows
+        # (the main-CI flake this replaced). Stamps are written after the
+        # deletes on the same puller thread, so once they are visible every
+        # assertion below is a deterministic consequence.
+        def _all_stamped() -> bool:
+            with gctx.db.read() as conn:
+                row = conn.execute(
+                    "SELECT count(*) FROM gdrive_pulls WHERE pruned_at IS NOT NULL"
+                ).fetchone()
+            return int(row[0]) == len(ids)
+
+        _wait_for(_all_stamped, "prune stamps of the imported set")
         # Prune ran only after the import completed and was verified.
         assert len(_completed_keep_runs(gctx)) == 1
+        assert sorted(mock.deleted) == sorted(ids)  # exact recorded ids, nothing else
         with gctx.db.read() as conn:
             assert storage_gdrive_pulls.list_prunable(conn) == []  # all stamped pruned
             assert storage_gdrive_pulls.count_pulls(conn) == 2  # history retained


### PR DESCRIPTION
## Problem

`tests/unit/services/test_gdrive_integration.py::test_prune_after_verified_import_end_to_end` failed on main CI after the P4 merge (756113f) with `assert [GDrivePullRe...uned_at=None)] == []` at the "all stamped pruned" assert, while the identical tree passed three PR CI runs — timing-sensitive, not deterministic.

## Mechanism (proven by forced reproduction)

The test's `_wait_for` was keyed on **`MockDrive.deleted`**, which `_prune` updates inside `client.delete()` **before** `ops.mark_pruned` queues its `Database.write` to the single writer thread. The test polls every 10 ms, so on a loaded runner it can win the race and read `list_prunable` inside the delete→stamp window — both rows still `pruned_at=None`, exactly the CI output (the earlier asserts pass: the import completed and the deletes happened).

Proof: a temporary 300 ms delay injected before `mark_pruned` reproduced the CI assertion **deterministically** on the old test; the fixed test passes under that same delay. Natural repro (30 loops under `-n auto` load) never fired locally — consistent with a narrow scheduler-dependent window.

Ruled out: a `started_at > max(pulled_at)` clock-granularity problem in the prune gate would present as the wait **timing out** (prune never firing), not as un-stamped rows after successful deletes.

## Fix (test-only; the conservative gate semantics are untouched)

Wait on the **durable terminal state** — `pruned_at` stamped on every row — after which each assertion (exact ids deleted remotely, `list_prunable` empty, history retained, single completed run) is a deterministic consequence, because the stamps are written after the deletes on the same puller thread. The exact-ids delete assertion is kept explicitly.

## Verification

- Old test under forced delay: fails with the exact CI assertion. New test under the same delay: passes.
- 50 sequential runs of the integration tests under a concurrent `-n auto` full-suite load: 0 failures.
- Full gate: `pytest -n auto` 1502 passed; ruff check / format clean; mypy clean (257 files); lint-imports 2/2 kept; PII guard exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUZWw9qidbJKy3eshZK8mT