### PR TITLE
perf: restore keep-ingest bench to pre-P4 parity (detection hot path)

### DIFF
--- a/src/potluck/ingest/plugins.py
+++ b/src/potluck/ingest/plugins.py
@@ -63,13 +63,14 @@ class Glob:
 
     @cached_property
     def _compiled(self) -> re.Pattern[str]:
-        # detect_sources calls matches() for every member name × every
-        # still-unmatched plugin — O(members × plugins) on single-source
-        # archives (nothing ever exhausts `remaining`). Per-call splitting +
-        # per-alternative fnmatchcase was ~40% of a Keep import's wall time
-        # once P4 grew the registry to 14 plugins; one combined regex keeps
-        # the whole check in C. fnmatch.translate is exactly fnmatchcase's
-        # internal compilation, so semantics are unchanged.
+        # Hot path: detection tests member names against globs for every
+        # archive member. Per-call splitting + per-alternative fnmatchcase
+        # was ~40% of a Keep import's wall time once P4 grew the registry to
+        # 14 plugins; one combined regex keeps the whole check in C.
+        # fnmatch.translate is exactly fnmatchcase's internal compilation, so
+        # semantics are unchanged. detect_sources additionally unions these
+        # compiled patterns across plugins (see _union_regex) so its
+        # per-member steady state is ONE C-level match, not one per plugin.
         return re.compile(
             "|".join(f"(?:{fnmatch.translate(alt)})" for alt in self.pattern.split("|"))
         )
@@ -182,6 +183,63 @@ def discover() -> dict[str, SourcePlugin]:
 # ---------------------------------------------------------------------------
 
 
+def _union_regex(remaining: dict[str, SourcePlugin]) -> re.Pattern[str] | None:
+    """One regex matching iff ANY remaining plugin's glob matches; None when empty.
+
+    detect_sources' steady state is a member name that matches NO remaining
+    plugin (a single-source archive never exhausts ``remaining``), so the
+    per-member cost must not scale with registry size. Reusing each Glob's
+    already-translated pattern keeps semantics bit-identical to calling
+    ``matches()`` per plugin; the union is rebuilt only when a plugin matches
+    (at most once per registered plugin per scan).
+    """
+    if not remaining:
+        return None
+    return re.compile(
+        "|".join(f"(?:{plugin.detect._compiled.pattern})" for plugin in remaining.values())
+    )
+
+
+_WILDCARD_SPLIT_RE: re.Pattern[str] = re.compile(r"[*?]")
+
+
+def _required_literal(alt: str) -> str | None:
+    """The longest wildcard-free run of glob alternative *alt*, or None.
+
+    Any name the alternative matches must CONTAIN every wildcard-free run
+    (wildcards only add characters around the runs), so the longest run is a
+    safe containment prefilter. An alternative with a character class is not
+    parsed (``[x]`` matches ``x`` — bracketed text is not literal): returning
+    None disables prefiltering rather than risking a wrong literal. So does
+    an all-wildcard alternative (no literal to require).
+    """
+    if "[" in alt:
+        return None
+    return max(_WILDCARD_SPLIT_RE.split(alt), key=len) or None
+
+
+def _prefilter_regex(remaining: dict[str, SourcePlugin]) -> re.Pattern[str] | None:
+    """Literal-containment prefilter for the union regex; None = cannot filter.
+
+    A regex of plain ``re.escape``-d literals, one per glob alternative of
+    every remaining plugin. Invariant: ``prefilter.search(name) is None``
+    implies ``_union_regex(remaining).match(name) is None`` — a miss proves
+    no remaining plugin matches. Pure-literal alternation fails ~5x faster
+    than the translated-glob union (measured 0.7 µs vs 3.6 µs per name at 12
+    plugins: sre's first-character charset scan vs per-branch ``.*`` heads),
+    and the steady state is exactly that miss. None (some alternative has no
+    usable literal) means the caller must run the union on every name.
+    """
+    literals: set[str] = set()
+    for plugin in remaining.values():
+        for alt in plugin.detect.pattern.split("|"):
+            lit = _required_literal(alt)
+            if lit is None:
+                return None
+            literals.add(lit)
+    return re.compile("|".join(map(re.escape, sorted(literals))))
+
+
 def detect_sources(archive: Archive) -> list[SourcePlugin]:
     """Single sequential pass over archive names; return EVERY matching plugin.
 
@@ -205,12 +263,38 @@ def detect_sources(archive: Archive) -> list[SourcePlugin]:
     remaining = dict(sorted(plugins.items()))
     matched: list[SourcePlugin] = []
 
+    # Three-stage check, cheapest first; the per-member steady state (a name
+    # matching NO remaining plugin) must not scale with registry size:
+    #   1. literal prefilter — a miss proves no remaining plugin matches;
+    #   2. union regex — answers "does ANY remaining plugin match?" in one
+    #      C-level call (also caps the cost of rare prefilter false
+    #      positives: a name containing a literal but matching no glob);
+    #   3. per-plugin loop — finds WHICH, only on true hits. Every hit
+    #      removes at least one plugin, so stages 1-2 are rebuilt at most
+    #      len(plugins) times per scan.
+    union = _union_regex(remaining)
+    prefilter = _prefilter_regex(remaining) if union is not None else None
     for archive_name in archive.iter_names():
+        # None ⇔ nothing left to match. Checked INSIDE the loop so an empty
+        # registry still pulls the first name — reading must start so a
+        # corrupt archive raises (→ UnsupportedArchiveError upstream) instead
+        # of reporting "no source plugin recognises" (behaviour pinned by
+        # test_background_failure_corrupt_archive).
+        if union is None:
+            break
+        if prefilter is not None and prefilter.search(archive_name) is None:
+            continue
+        if union.match(archive_name) is None:
+            continue
         for name in list(remaining):
             if remaining[name].detect.matches(archive_name):
                 matched.append(remaining.pop(name))
-        if not remaining:
+        union = _union_regex(remaining)
+        if union is None:
+            # Early exit: every plugin matched — stop before pulling the next
+            # name (single-pass contract; served-count pinned by test).
             break
+        prefilter = _prefilter_regex(remaining)
 
     if any(not plugin.generic for plugin in matched):
         dropped = sorted(plugin.name for plugin in matched if plugin.generic)

--- a/src/potluck/ingest/plugins.py
+++ b/src/potluck/ingest/plugins.py
@@ -9,9 +9,11 @@ import hashlib
 import importlib
 import logging
 import pkgutil
+import re
 import sys
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
+from functools import cached_property
 from pathlib import Path
 
 import potluck.ingest.sources as sources_pkg
@@ -59,9 +61,22 @@ class Glob:
 
     pattern: str
 
+    @cached_property
+    def _compiled(self) -> re.Pattern[str]:
+        # detect_sources calls matches() for every member name × every
+        # still-unmatched plugin — O(members × plugins) on single-source
+        # archives (nothing ever exhausts `remaining`). Per-call splitting +
+        # per-alternative fnmatchcase was ~40% of a Keep import's wall time
+        # once P4 grew the registry to 14 plugins; one combined regex keeps
+        # the whole check in C. fnmatch.translate is exactly fnmatchcase's
+        # internal compilation, so semantics are unchanged.
+        return re.compile(
+            "|".join(f"(?:{fnmatch.translate(alt)})" for alt in self.pattern.split("|"))
+        )
+
     def matches(self, name: str) -> bool:
         """Return True if *name* matches any of this glob's alternatives."""
-        return any(fnmatch.fnmatchcase(name, alt) for alt in self.pattern.split("|"))
+        return self._compiled.match(name) is not None
 
 
 @dataclass(frozen=True)

--- a/tests/unit/ingest/test_plugins.py
+++ b/tests/unit/ingest/test_plugins.py
@@ -258,3 +258,59 @@ def test_detect_sources_single_pass_early_exit(clean_registry: dict[str, Any]) -
     assert counting.served == 1, (
         f"Expected early exit after 1 archive name, got {counting.served} served"
     )
+
+
+def test_detect_sources_empty_registry(clean_registry: dict[str, Any]) -> None:
+    """No registered plugins -> no matches, and the scan does not blow up."""
+    from potluck.ingest.plugins import detect_sources
+
+    assert detect_sources(FakeArchive(["a.txt", "b.json"])) == []
+
+
+def test_required_literal_extraction() -> None:
+    """The prefilter literal is the longest wildcard-free run — or None
+    (character class / all-wildcard alternatives cannot be filtered)."""
+    from potluck.ingest.plugins import _required_literal
+
+    assert _required_literal("*Keep/*.json") == "Keep/"
+    assert _required_literal("*.txt") == ".txt"
+    assert _required_literal("Timeline.json") == "Timeline.json"
+    assert _required_literal("*note[0-9].json") is None
+    assert _required_literal("*") is None
+    assert _required_literal("???") is None
+
+
+def test_detect_sources_character_class_glob(clean_registry: dict[str, Any]) -> None:
+    """A '[' alternative disables the literal prefilter for the whole scan;
+    detection results must be identical either way."""
+    from potluck.ingest.plugins import Glob, detect_sources, source
+
+    @source(name="classy", detect=Glob("*report-[0-9].csv"), kinds=(ItemKind.NOTE,))
+    def parse_classy(archive: Archive, ctx: ParseContext) -> Iterator[NoteDraft]:
+        notes: list[NoteDraft] = []
+        yield from notes
+
+    @source(name="plain", detect=Glob("*Keep/*.json"), kinds=(ItemKind.NOTE,))
+    def parse_plain(archive: Archive, ctx: ParseContext) -> Iterator[NoteDraft]:
+        notes: list[NoteDraft] = []
+        yield from notes
+
+    both = FakeArchive(["data/report-3.csv", "Takeout/Keep/a.json"])
+    assert [p.name for p in detect_sources(both)] == ["classy", "plain"]
+    assert [p.name for p in detect_sources(FakeArchive(["report-x.csv"]))] == []
+
+
+def test_detect_sources_prefilter_false_positive(clean_registry: dict[str, Any]) -> None:
+    """A name CONTAINING a glob's literal but matching no glob must not match
+    (the prefilter only proves misses; the union confirms hits)."""
+    from potluck.ingest.plugins import Glob, detect_sources, source
+
+    @source(name="txt_plugin", detect=Glob("*.txt"), kinds=(ItemKind.NOTE,))
+    def parse_txt(archive: Archive, ctx: ParseContext) -> Iterator[NoteDraft]:
+        notes: list[NoteDraft] = []
+        yield from notes
+
+    assert detect_sources(FakeArchive(["backup.txt.gz"])) == []
+    assert [p.name for p in detect_sources(FakeArchive(["backup.txt.gz", "real.txt"]))] == [
+        "txt_plugin"
+    ]


### PR DESCRIPTION
## Summary

The nightly ±30% gate caught a real P4 regression: all `ingest_keep_*` scenarios +34-38% on CI. Root cause: `detect_sources` tests every member name against every still-unmatched plugin, and P4 grew the registry to 14 — with `Glob.matches` re-splitting alternatives and looping `fnmatchcase` per call, detection became O(members × plugins × alternatives) in pure Python.

Two commits:
- **4114b8d** — each Glob precompiles its alternatives into one combined regex (cached; `fnmatch.translate` is exactly `fnmatchcase`'s internal compilation, so semantics and the registry fingerprint are unchanged).
- **a6b03d3** — `detect_sources` unions the remaining plugins' compiled patterns (rebuilt only when a plugin matches) behind a required-literal prefilter, making the steady-state per-member cost one C-level match instead of one per plugin. Detection results bit-identical; +4 tests.

Interleaved local A/B vs pre-P4 724d400 (pooled 9-rep medians, equal interpreters): keep_2k 0.174→0.178 (+2.2%), keep_8k 0.620→0.645 (+4.1%), keep_10k 0.776→0.794 (+2.4%). The remaining ~0.8µs/member is the measured floor of P4 features (Member.mtime, suppressed-hashes anti-join).

Also for the record: my earlier "runner noise" comment on #211 was wrong — the A/B behind it had run both sides in the same worktree (cd leak), and a further ~42µs/member of the local reproduction turned out to be a stale-interpreter venv artifact. The CI gate was right.

Full gate green: 1506 unit tests, ruff/format/mypy strict/lint-imports/PII guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUZWw9qidbJKy3eshZK8mT